### PR TITLE
remove abbreviation check

### DIFF
--- a/coding-style/java/checkstyle.xml
+++ b/coding-style/java/checkstyle.xml
@@ -253,14 +253,6 @@
       <property name="lineWrappingIndentation" value="4"/>
       <property name="arrayInitIndent" value="4"/>
     </module>
-    <module name="AbbreviationAsWordInName">
-      <property name="ignoreFinal" value="false"/>
-      <property name="allowedAbbreviationLength" value="0"/>
-      <property name="tokens"
-               value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, ANNOTATION_DEF, ANNOTATION_FIELD_DEF,
-                    PARAMETER_DEF, VARIABLE_DEF, METHOD_DEF, PATTERN_VARIABLE_DEF, RECORD_DEF,
-                    RECORD_COMPONENT_DEF"/>
-    </module>
     <module name="OverloadMethodsDeclarationOrder"/>
     <module name="VariableDeclarationUsageDistance"/>
     <module name="CustomImportOrder">


### PR DESCRIPTION
Before this, the checks would complain about variable and method names like `resourceContextUUID` , since `UUID` is an abbreviation. We have a lot of these and with names that are clearer *with* the abbreviation. This change removes the restriction.

I've run the tests in a repository with and without this change and confirm expected behavior.